### PR TITLE
Fix bugs

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -27,6 +27,11 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/fallery/build.gradle
+++ b/fallery/build.gradle
@@ -33,6 +33,11 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketContent/BaseBucketContentFragment.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketContent/BaseBucketContentFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import ir.mehdiyari.fallery.R
 import ir.mehdiyari.fallery.buckets.bucketContent.content.BucketContentFragment
@@ -42,7 +41,7 @@ internal class BaseBucketContentFragment : Fragment() {
             this,
             FalleryActivityComponentHolder.createOrGetComponent(requireActivity()).provideBucketContentViewModelFactory()
         )[BucketContentViewModel::class.java].apply {
-            showPreviewFragmentLiveData.observe(viewLifecycleOwner, Observer {
+            showPreviewFragmentLiveData.observe(viewLifecycleOwner, {
                 if (it != null) {
                     navigateToPreviewFragment(fromMediaPath = it)
                 }

--- a/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketContent/content/BucketContentFragment.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketContent/content/BucketContentFragment.kt
@@ -117,7 +117,8 @@ internal class BucketContentFragment : Fragment(R.layout.fragment_bucket_content
     }
 
     override fun onDestroyView() {
-        recyclerViewBucketContent.adapter = null
+        recyclerViewBucketContent?.adapter = null
+        recyclerViewBucketContent?.layoutManager = null
         super.onDestroyView()
     }
 }

--- a/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketContent/content/BucketContentFragment.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketContent/content/BucketContentFragment.kt
@@ -100,7 +100,7 @@ internal class BucketContentFragment : Fragment(R.layout.fragment_bucket_content
         recyclerViewBucketContent.visibility = View.GONE
         errorLayoutBucketContent.show()
         errorLayoutBucketContent.setOnRetryClickListener {
-            bucketContentViewModel.retry(arguments!!.getLong("bucket_id"))
+            bucketContentViewModel.retry(requireArguments().getLong("bucket_id"))
         }
     }
 

--- a/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketContent/preview/PreviewFragment.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketContent/preview/PreviewFragment.kt
@@ -187,7 +187,6 @@ internal class PreviewFragment : Fragment(R.layout.fragment_preview), View.OnCli
 
     override fun onStop() {
         viewPagerMediaPreview.unregisterOnPageChangeCallback(pageSelectedCallback)
-        viewPagerMediaPreview.adapter = null
         super.onStop()
     }
 

--- a/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketList/BucketListFragment.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketList/BucketListFragment.kt
@@ -167,7 +167,8 @@ internal class BucketListFragment : Fragment(R.layout.fragment_bucket_list) {
     } else 1
 
     override fun onDestroyView() {
-        recyclerViewBuckets.adapter = null
+        recyclerViewBuckets?.adapter = null
+        recyclerViewBuckets?.layoutManager = null
         super.onDestroyView()
     }
 }

--- a/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketList/BucketListFragment.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketList/BucketListFragment.kt
@@ -79,7 +79,7 @@ internal class BucketListFragment : Fragment(R.layout.fragment_bucket_list) {
 
         bucketListViewModel = ViewModelProvider(
             this,
-            FalleryActivityComponentHolder.componentCreator(requireActivity()).provideBucketListViewModelFactory()
+            FalleryActivityComponentHolder.createOrGetComponent(requireActivity()).provideBucketListViewModelFactory()
         )[BucketListViewModel::class.java]
 
         viewLifecycleOwner.lifecycleScope.launch {

--- a/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketList/BucketListFragment.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/buckets/bucketList/BucketListFragment.kt
@@ -6,7 +6,6 @@ import android.transition.TransitionManager
 import android.view.View
 import android.view.animation.AlphaAnimation
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
@@ -72,7 +71,7 @@ internal class BucketListFragment : Fragment(R.layout.fragment_bucket_list) {
             requireActivity(),
             FalleryActivityComponentHolder.createOrGetComponent(requireActivity()).provideFalleryViewModelFactory()
         )[FalleryViewModel::class.java].apply {
-            bucketRecycleViewModeLiveData.observe(viewLifecycleOwner, Observer {
+            bucketRecycleViewModeLiveData.observe(viewLifecycleOwner, {
                 changeRecyclerViewItemModeTo(it)
             })
         }

--- a/fallery/src/main/java/ir/mehdiyari/fallery/main/ui/FalleryActivity.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/main/ui/FalleryActivity.kt
@@ -118,7 +118,7 @@ internal class FalleryActivity : AppCompatActivity(), FalleryToolbarVisibilityCo
             }
         }
 
-        falleryViewModel.currentFragmentLiveData.observe(this@FalleryActivity, Observer { falleryView ->
+        falleryViewModel.currentFragmentLiveData.observe(this@FalleryActivity, { falleryView ->
             replaceFragment(falleryView)
         })
     }
@@ -395,7 +395,7 @@ internal class FalleryActivity : AppCompatActivity(), FalleryToolbarVisibilityCo
             } catch (ignored: Throwable) {
                 Log.e(FALLERY_LOG_TAG, "error while inflating captionLayoutResId. switch to default implementation")
                 LayoutInflater.from(this).inflate(R.layout.caption_edit_text_layout, frameLayoutCaptionHolder, false)
-                    .findViewById<AppCompatEditText>(R.id.falleryEditTextCaption)
+                    .findViewById(R.id.falleryEditTextCaption)
             }).also {
                 frameLayoutCaptionHolder.addView(it)
             }

--- a/fallery/src/main/java/ir/mehdiyari/fallery/main/ui/FalleryActivity.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/main/ui/FalleryActivity.kt
@@ -52,6 +52,11 @@ internal class FalleryActivity : AppCompatActivity(), FalleryToolbarVisibilityCo
     private val falleryOptions by lazy { FalleryActivityComponentHolder.createOrGetComponent(this).provideFalleryOptions() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        try {
+            FalleryCoreComponentHolder.getOrThrow()
+        } catch (t: Throwable) {
+            finish()
+        }
         FalleryActivityComponentHolder.createOrGetComponent(this)
         requestedOrientation = falleryOptions.orientationMode
         setTheme(falleryOptions.themeResId)

--- a/fallery/src/main/java/ir/mehdiyari/fallery/utils/BitmapUtils.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/utils/BitmapUtils.kt
@@ -41,7 +41,7 @@ internal fun createCircleDrawableWithStroke(
     @ColorInt backgroundColor: Int,
     strokeWidth: Int,
     @ColorInt strokeColor: Int
-): Drawable? {
+): Drawable {
     val defaultDrawable = GradientDrawable(GradientDrawable.Orientation.TOP_BOTTOM, intArrayOf(backgroundColor, backgroundColor))
     defaultDrawable.cornerRadius = 300f
     defaultDrawable.setStroke(strokeWidth, strokeColor)

--- a/fallery/src/main/java/ir/mehdiyari/fallery/utils/PermissionHelper.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/utils/PermissionHelper.kt
@@ -3,27 +3,12 @@ package ir.mehdiyari.fallery.utils
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.FragmentActivity
 
 
 internal inline fun AppCompatActivity.permissionChecker(
     permission: String,
     granted: () -> Unit = {},
     denied: () -> Unit = {}
-) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        if (checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED) {
-            denied()
-        } else {
-            granted()
-        }
-    } else {
-        granted()
-    }
-}
-
-internal inline fun FragmentActivity.permissionChecker(
-    permission: String, granted: () -> Unit, denied: () -> Unit
 ) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         if (checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED) {

--- a/fallery/src/main/java/ir/mehdiyari/fallery/utils/SingleLiveEvent.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/utils/SingleLiveEvent.kt
@@ -11,7 +11,7 @@ internal class SingleLiveEvent<T> : MutableLiveData<T>() {
 
     @MainThread
     override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
-        super.observe(owner, Observer { t ->
+        super.observe(owner, { t ->
             if (mPending.compareAndSet(true, false)) {
                 observer.onChanged(t)
             }

--- a/fallery/src/main/res/layout/activity_fallery.xml
+++ b/fallery/src/main/res/layout/activity_fallery.xml
@@ -73,7 +73,7 @@
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
         app:rippleColor="#ffffff"
-        tools:ignore="RtlHardcoded,UnusedAttribute"
+        tools:ignore="ContentDescription,RtlHardcoded,UnusedAttribute"
         tools:visibility="visible" />
 
 

--- a/fallery/src/main/res/layout/fragment_bucket_content.xml
+++ b/fallery/src/main/res/layout/fragment_bucket_content.xml
@@ -23,7 +23,8 @@
         android:id="@+id/errorLayoutBucketContent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        android:visibility="gone" />
 
     <ProgressBar
         android:id="@+id/contentLoadingProgressBarBucketContent"

--- a/fallery/src/main/res/layout/fragment_bucket_list.xml
+++ b/fallery/src/main/res/layout/fragment_bucket_list.xml
@@ -18,7 +18,8 @@
         android:id="@+id/errorLayoutBucketList"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        android:visibility="gone" />
 
     <ProgressBar
         android:id="@+id/contentLoadingProgressBarBucketList"


### PR DESCRIPTION
1. Fix lint errors and warnings
2. Fix memory leak of gridLayoutManagers in BucketContentFragment & BucketListFragment
3. Fix animation of sending media footer
4. Fix bug of resetting viewpager adapter position after onStop
5. Fix issue of media store observable
6. Fix the issue of creating two instances of FalleryActivityComponent
7. Set source compatibility to Java 1.8
8. Fix issue of showing error layout when views is on loading state
9. Finish fallery activity if CoreComponent is null(if permissions changed from settings or any case that fallery started without official API)