### PR TITLE
Support starting fallery from composable functions

### DIFF
--- a/example/src/main/java/ir/mehdiyari/falleryExample/ui/MainActivity.kt
+++ b/example/src/main/java/ir/mehdiyari/falleryExample/ui/MainActivity.kt
@@ -1,7 +1,5 @@
 package ir.mehdiyari.falleryExample.ui
 
-import android.app.Activity
-import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Bundle
@@ -19,9 +17,7 @@ import ir.mehdiyari.fallery.main.fallery.CaptionEnabledOptions
 import ir.mehdiyari.fallery.main.fallery.FalleryBucketsSpanCountMode
 import ir.mehdiyari.fallery.main.fallery.FalleryBuilder
 import ir.mehdiyari.fallery.main.fallery.FalleryOptions
-import ir.mehdiyari.fallery.main.fallery.getFalleryCaptionFromIntent
-import ir.mehdiyari.fallery.main.fallery.getFalleryResultMediasFromIntent
-import ir.mehdiyari.fallery.main.fallery.startFalleryWithOptions
+import ir.mehdiyari.fallery.main.fallery.registerFalleryResultCallback
 import ir.mehdiyari.fallery.models.BucketType
 import ir.mehdiyari.falleryExample.R
 import ir.mehdiyari.falleryExample.databinding.ActivityMainBinding
@@ -37,10 +33,13 @@ class MainActivity : AppCompatActivity() {
 
     private val fileProviderAuthority by lazy { "${application.packageName}.provider" }
     private var itemIdSelected: Int = R.id.menuDefaultOptions
-    private val falleryRequestCode = 830
     private val mediaAdapter by lazy { MediaAdapter() }
     private var listCurrentMedias = listOf<Pair<String, String>>()
     private val glideImageLoader by lazy { GlideImageLoader() }
+    private val falleryActivityResult =
+        registerFalleryResultCallback(onResult = { result, caption ->
+            handleFalleryResult(result, caption)
+        })
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -117,6 +116,7 @@ class MainActivity : AppCompatActivity() {
                     .setImageLoader(glideImageLoader).setMediaObserverEnabled(true)
                     .build()
             }
+
             R.id.menuCameraEnabled -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
@@ -127,48 +127,56 @@ class MainActivity : AppCompatActivity() {
                         )
                     ).build()
             }
+
             R.id.menuFilterTypePhoto -> {
                 FalleryBuilder()
                     .mediaTypeFiltering(BucketType.ONLY_PHOTO_BUCKETS)
                     .setImageLoader(glideImageLoader)
                     .build()
             }
+
             R.id.menuFilterTypeVideo -> {
                 FalleryBuilder()
                     .mediaTypeFiltering(BucketType.ONLY_VIDEO_BUCKETS)
                     .setImageLoader(glideImageLoader)
                     .build()
             }
+
             R.id.menuWithCaption -> {
                 FalleryBuilder()
                     .setCaptionEnabledOptions(CaptionEnabledOptions(enabled = true))
                     .setImageLoader(glideImageLoader)
                     .build()
             }
+
             R.id.menuDraculaTheme -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
                     .setTheme(ir.mehdiyari.fallery.R.style.Fallery_Dracula)
                     .build()
             }
+
             R.id.menuLandscapeOrientation -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
                     .setOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE)
                     .build()
             }
+
             R.id.menuPreviewScrollOrientation -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
                     .setMediaPreviewViewPagerOrientation(ViewPager2.ORIENTATION_VERTICAL)
                     .build()
             }
+
             R.id.menuMaxSelectable -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
                     .setMaxSelectableMedia(5)
                     .build()
             }
+
             R.id.menuWithCustomVideoToggleOnClick -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
@@ -177,6 +185,7 @@ class MainActivity : AppCompatActivity() {
                     }
                     .build()
             }
+
             R.id.menuBucketListModeGrid -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
@@ -184,6 +193,7 @@ class MainActivity : AppCompatActivity() {
                     .setBucketItemMode(BucketRecyclerViewItemMode.GridStyle)
                     .build()
             }
+
             R.id.menuBucketListModeVertical -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
@@ -191,19 +201,25 @@ class MainActivity : AppCompatActivity() {
                     .setBucketItemMode(BucketRecyclerViewItemMode.LinearStyle)
                     .build()
             }
+
             R.id.menuWithCustomSelectToggleBackColor -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
                     .setSelectedMediaToggleBackgroundColor(Color.RED)
                     .build()
             }
+
             R.id.menuCustomOnlineGallery -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
-                    .setContentProviders(CustomOnlineBucketContentProvider(), CustomOnlineBucketProvider())
+                    .setContentProviders(
+                        CustomOnlineBucketContentProvider(),
+                        CustomOnlineBucketProvider()
+                    )
                     .setMediaObserverEnabled(false)
                     .build()
             }
+
             R.id.menuWitCustomCaptionEditText -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
@@ -213,29 +229,44 @@ class MainActivity : AppCompatActivity() {
                         )
                     ).build()
             }
+
             R.id.menuCustomTheme -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
                     .setTheme(R.style.Fallery_Blue_Theme)
                     .build()
             }
+
             R.id.menuSpanCount -> {
                 FalleryBuilder()
                     .setImageLoader(glideImageLoader)
                     .setFallerySpanCountMode(FalleryBucketsSpanCountMode.UserZoomInOrZoomOut)
                     .build()
             }
+
             else -> FalleryOptions(glideImageLoader)
-        })?.also {
-            startFalleryWithOptions(falleryRequestCode, it)
+        }).also {
+            falleryActivityResult.launch(it)
         }
+    }
+
+    private fun handleFalleryResult(result: Array<String>?, caption: String?) {
+        listCurrentMedias = mutableListOf<Pair<String, String>>().apply {
+            addAll(listCurrentMedias)
+            result?.onEach { add(it to (caption ?: "")) }
+        }
+
+        visibleRecyclerViewIfCurrentListIsNotEmpty()
+        mediaAdapter.submitList(listCurrentMedias)
     }
 
     private fun animateLayouts() {
         Handler(Looper.getMainLooper()).postDelayed({
             Handler(Looper.getMainLooper()).postDelayed({
-                binding.bottomAppBarExample.fabCradleMargin = resources.getDimension(R.dimen.min_fabCradleMargin)
-                binding.bottomAppBarExample.fabCradleRoundedCornerRadius = resources.getDimension(R.dimen.min_fabCradleRoundedCornerRadius)
+                binding.bottomAppBarExample.fabCradleMargin =
+                    resources.getDimension(R.dimen.min_fabCradleMargin)
+                binding.bottomAppBarExample.fabCradleRoundedCornerRadius =
+                    resources.getDimension(R.dimen.min_fabCradleRoundedCornerRadius)
             }, 60)
             binding.fabOpenFallery.startAnimation(
                 TranslateAnimation(
@@ -249,8 +280,10 @@ class MainActivity : AppCompatActivity() {
 
         Handler(Looper.getMainLooper()).postDelayed({
             Handler(Looper.getMainLooper()).postDelayed({
-                binding.bottomAppBarExample.fabCradleMargin = resources.getDimension(R.dimen.fabCradleMargin)
-                binding.bottomAppBarExample.fabCradleRoundedCornerRadius = resources.getDimension(R.dimen.fabCradleRoundedCornerRadius)
+                binding.bottomAppBarExample.fabCradleMargin =
+                    resources.getDimension(R.dimen.fabCradleMargin)
+                binding.bottomAppBarExample.fabCradleRoundedCornerRadius =
+                    resources.getDimension(R.dimen.fabCradleRoundedCornerRadius)
             }, 60)
             binding.fabOpenFallery.startAnimation(
                 TranslateAnimation(
@@ -263,24 +296,6 @@ class MainActivity : AppCompatActivity() {
         }, 450)
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == falleryRequestCode) {
-            if (resultCode == Activity.RESULT_OK && data != null) {
-                listCurrentMedias = mutableListOf<Pair<String, String>>().apply {
-                    addAll(listCurrentMedias)
-                    val caption = data.getFalleryCaptionFromIntent()
-                    data.getFalleryResultMediasFromIntent()?.onEach {
-                        add(it to (caption ?: ""))
-                    }
-                }
-
-                visibleRecyclerViewIfCurrentListIsNotEmpty()
-                mediaAdapter.submitList(listCurrentMedias)
-            }
-        }
-        super.onActivityResult(requestCode, resultCode, data)
-    }
-
     override fun onDestroy() {
         if (isFinishing) FalleryExample.customGalleryApiService = null
         binding.bottomAppBarExample.setNavigationOnClickListener(null)
@@ -289,7 +304,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putInt("itemIdSelected", itemIdSelected)
-        outState.putStringArray("results", listCurrentMedias.map { "${it.first}~|~${it.second}" }.toTypedArray())
+        outState.putStringArray(
+            "results",
+            listCurrentMedias.map { "${it.first}~|~${it.second}" }.toTypedArray()
+        )
         super.onSaveInstanceState(outState)
     }
 }

--- a/example/src/main/java/ir/mehdiyari/falleryExample/ui/MainActivity.kt
+++ b/example/src/main/java/ir/mehdiyari/falleryExample/ui/MainActivity.kt
@@ -37,8 +37,8 @@ class MainActivity : AppCompatActivity() {
     private var listCurrentMedias = listOf<Pair<String, String>>()
     private val glideImageLoader by lazy { GlideImageLoader() }
     private val falleryActivityResult =
-        registerFalleryResultCallback(onResult = { result, caption ->
-            handleFalleryResult(result, caption)
+        registerFalleryResultCallback(onResult = { result ->
+            handleFalleryResult(result.mediaPathList, result.caption)
         })
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -250,7 +250,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun handleFalleryResult(result: Array<String>?, caption: String?) {
+    private fun handleFalleryResult(result: List<String>?, caption: String?) {
         listCurrentMedias = mutableListOf<Pair<String, String>>().apply {
             addAll(listCurrentMedias)
             result?.onEach { add(it to (caption ?: "")) }

--- a/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/Fallery.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/Fallery.kt
@@ -26,20 +26,10 @@ fun Activity.startFalleryWithOptions(requestCode: Int, falleryOptions: FalleryOp
 
 @JvmName("registerFalleryResultCallback")
 fun AppCompatActivity.registerFalleryResultCallback(
-    onResult: (Array<String>?, String?) -> Unit,
-): ActivityResultLauncher<FalleryOptions> = registerForActivityResult(object :
-    ActivityResultContract<FalleryOptions, Pair<Array<String>?, String?>>() {
-    override fun createIntent(context: Context, input: FalleryOptions): Intent {
-        FalleryCoreComponentHolder.createComponent(input)
-        return Intent(context, FalleryActivity::class.java)
-    }
-
-    override fun parseResult(resultCode: Int, intent: Intent?): Pair<Array<String>?, String?> {
-        return intent?.getFalleryResultMediasFromIntent() to intent?.getFalleryCaptionFromIntent()
-    }
-}) {
-    onResult(it.first, it.second)
-}
+    onResult: (FalleryResult) -> Unit,
+): ActivityResultLauncher<FalleryOptions> = registerForActivityResult(
+    getFalleryActivityResultContract(), onResult
+)
 
 @JvmName("startFalleryFromFragmentWithOptions")
 @Deprecated(
@@ -53,20 +43,10 @@ fun Fragment.startFalleryWithOptions(requestCode: Int, falleryOptions: FalleryOp
 
 @JvmName("registerFalleryResultCallback")
 fun Fragment.registerFalleryResultCallback(
-    onResult: (Array<String>?, String?) -> Unit,
-): ActivityResultLauncher<FalleryOptions> = registerForActivityResult(object :
-    ActivityResultContract<FalleryOptions, Pair<Array<String>?, String?>>() {
-    override fun createIntent(context: Context, input: FalleryOptions): Intent {
-        FalleryCoreComponentHolder.createComponent(input)
-        return Intent(context, FalleryActivity::class.java)
-    }
-
-    override fun parseResult(resultCode: Int, intent: Intent?): Pair<Array<String>?, String?> {
-        return intent?.getFalleryResultMediasFromIntent() to intent?.getFalleryCaptionFromIntent()
-    }
-}) {
-    onResult(it.first, it.second)
-}
+    onResult: (FalleryResult) -> Unit,
+): ActivityResultLauncher<FalleryOptions> = registerForActivityResult(
+    getFalleryActivityResultContract(), onResult
+)
 
 @JvmName("getResultMediasFromIntent")
 fun Intent.getFalleryResultMediasFromIntent(): Array<String>? {

--- a/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/Fallery.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/Fallery.kt
@@ -3,7 +3,11 @@
 package ir.mehdiyari.fallery.main.fallery
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import ir.mehdiyari.fallery.main.di.FalleryCoreComponentHolder
 import ir.mehdiyari.fallery.main.ui.FalleryActivity
@@ -11,15 +15,57 @@ import ir.mehdiyari.fallery.utils.FALLERY_CAPTION_KEY
 import ir.mehdiyari.fallery.utils.FALLERY_MEDIAS_LIST_KEY
 
 @JvmName("startFalleryFromActivityWithOptions")
+@Deprecated(
+    "Deprecated, Please use [registerFalleryResultCallback] instead.",
+    level = DeprecationLevel.WARNING,
+)
 fun Activity.startFalleryWithOptions(requestCode: Int, falleryOptions: FalleryOptions) {
     FalleryCoreComponentHolder.createComponent(falleryOptions)
     startActivityForResult(Intent(this, FalleryActivity::class.java), requestCode)
 }
 
+@JvmName("registerFalleryResultCallback")
+fun AppCompatActivity.registerFalleryResultCallback(
+    onResult: (Array<String>?, String?) -> Unit,
+): ActivityResultLauncher<FalleryOptions> = registerForActivityResult(object :
+    ActivityResultContract<FalleryOptions, Pair<Array<String>?, String?>>() {
+    override fun createIntent(context: Context, input: FalleryOptions): Intent {
+        FalleryCoreComponentHolder.createComponent(input)
+        return Intent(context, FalleryActivity::class.java)
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Pair<Array<String>?, String?> {
+        return intent?.getFalleryResultMediasFromIntent() to intent?.getFalleryCaptionFromIntent()
+    }
+}) {
+    onResult(it.first, it.second)
+}
+
 @JvmName("startFalleryFromFragmentWithOptions")
+@Deprecated(
+    "Deprecated, Please use [registerFalleryResultCallback] instead.",
+    level = DeprecationLevel.WARNING,
+)
 fun Fragment.startFalleryWithOptions(requestCode: Int, falleryOptions: FalleryOptions) {
     FalleryCoreComponentHolder.createComponent(falleryOptions)
     startActivityForResult(Intent(this.requireContext(), FalleryActivity::class.java), requestCode)
+}
+
+@JvmName("registerFalleryResultCallback")
+fun Fragment.registerFalleryResultCallback(
+    onResult: (Array<String>?, String?) -> Unit,
+): ActivityResultLauncher<FalleryOptions> = registerForActivityResult(object :
+    ActivityResultContract<FalleryOptions, Pair<Array<String>?, String?>>() {
+    override fun createIntent(context: Context, input: FalleryOptions): Intent {
+        FalleryCoreComponentHolder.createComponent(input)
+        return Intent(context, FalleryActivity::class.java)
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Pair<Array<String>?, String?> {
+        return intent?.getFalleryResultMediasFromIntent() to intent?.getFalleryCaptionFromIntent()
+    }
+}) {
+    onResult(it.first, it.second)
 }
 
 @JvmName("getResultMediasFromIntent")

--- a/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/Fallery.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/Fallery.kt
@@ -75,7 +75,7 @@ fun Intent.getFalleryCaptionFromIntent(): String? = this.getStringExtra(FALLERY_
  *      }
  *
  *      Button(onClick = { falleryLauncher.launch(falleryOptions) }) {
- *             Text(text = "Take a picture")
+ *             Text(text = "Open Fallery")
  *      }
  *
  * </pre>

--- a/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/Fallery.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/Fallery.kt
@@ -79,3 +79,42 @@ fun Intent.getFalleryResultMediasFromIntent(): Array<String>? {
 
 @JvmName("getCaptionFromIntent")
 fun Intent.getFalleryCaptionFromIntent(): String? = this.getStringExtra(FALLERY_CAPTION_KEY)
+
+
+/**
+ * API for getting [ActivityResultContract] for register activityResult.
+ * This API can be used inside composable functions for starting fallery and get the result.
+ *
+ * <p>
+ * <pre>
+ *
+ *      val falleryLauncher = rememberLauncherForActivityResult(
+ *             getFalleryActivityResultContract()
+ *      ) { result ->
+ *             doSomethingWithPhotosAndCaption(result.mediaPathList, result.caption)
+ *      }
+ *
+ *      Button(onClick = { falleryLauncher.launch(falleryOptions) }) {
+ *             Text(text = "Take a picture")
+ *      }
+ *
+ * </pre>
+ * </p>
+ *
+ */
+@JvmName("getFalleryActivityResultContract")
+fun getFalleryActivityResultContract(): ActivityResultContract<FalleryOptions, FalleryResult> {
+    return object : ActivityResultContract<FalleryOptions, FalleryResult>() {
+        override fun createIntent(context: Context, input: FalleryOptions): Intent {
+            FalleryCoreComponentHolder.createComponent(input)
+            return Intent(context, FalleryActivity::class.java)
+        }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): FalleryResult {
+            return FalleryResult(
+                intent?.getFalleryResultMediasFromIntent()?.toList(),
+                intent?.getFalleryCaptionFromIntent()
+            )
+        }
+    }
+}

--- a/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/FalleryResult.kt
+++ b/fallery/src/main/java/ir/mehdiyari/fallery/main/fallery/FalleryResult.kt
@@ -1,0 +1,6 @@
+package ir.mehdiyari.fallery.main.fallery
+
+data class FalleryResult(
+    val mediaPathList: List<String>? = null,
+    val caption: String? = null
+)


### PR DESCRIPTION
Fallery support register callback for activity results so we can start the Fallery from composable functions like the one below without any problem. 

```Kotlin
val falleryLauncher = rememberLauncherForActivityResult(
              getFalleryActivityResultContract()
) { result ->
    doSomethingWithPhotosAndCaption(result.mediaPathList, result.caption)
}
 
Button(onClick = { falleryLauncher.launch(falleryOptions) }) {
      Text(text = "Open Fallery")
}
```